### PR TITLE
perf: Apply decompression speedup from PR #42

### DIFF
--- a/Platform/Apple/virtual/src/core/decomp.s
+++ b/Platform/Apple/virtual/src/core/decomp.s
@@ -33,8 +33,9 @@ DEBUG	= 0
 decomp	!zone {
 	jsr .chkdst
 	ldy #0		; In lit loop Y must be zero
+        sec
 .fill1A	jsr .getbt2
-	jmp .fill1B
+	bne .fill1B     ; always taken
 
 .incdst	inc pDst+1
 .chkdst	ldx pDst+1
@@ -174,19 +175,19 @@ decomp	!zone {
 	bne .gshift	; always taken
 
 ; Get another 8 bits into our bit buffer. Destroys X. Preserves A. Requires Y=0.
+; Carry is always set on entry, Z always clear on exit
 ; Alternately, use .getbt2 to preserve X and destroy A
 .getbts	tax
 .getbt2	lda (pSrc),y
-	inc pSrc
-	beq .src3A
-.src3B	sec
 	rol
 	sta bits
 	txa
+	inc pSrc
+	beq .src3A
 	rts
 
 .src3A	inc pSrc+1
-	bne .src3B	; always taken
+	rts
 
 } ; end of zone
 


### PR DESCRIPTION
Cherry-picked optimization improvements from Peter Ferrie's PR #42:
- Move sec out of hot path (set once instead of repeatedly)
- Replace jmp with bne (2 cycles vs 3)
- Eliminate redundant branching in .src3A
- Reorder instructions to avoid pipeline stalls

This provides measurable speedup in the decompression loop which runs frequently during game loading.

Original commit: b258ed44 by Peter Ferrie